### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ With npm:
 npm install --save vue-visible
 ```
 
+With CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/vue-visible@1/dist/v-visible.min.js"></script>
+```
+
 ## Usage
 
 If you're using modules, first import it:


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/vue-visible) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage. 